### PR TITLE
Fix IE11 compatibility, stop using Array.from

### DIFF
--- a/demo/src/Demo.js
+++ b/demo/src/Demo.js
@@ -2,14 +2,18 @@ import React from 'react';
 import CalendarHeatmap from 'react-calendar-heatmap';
 import ReactTooltip from 'react-tooltip';
 
-export function shiftDate(date, numDays) {
+function shiftDate(date, numDays) {
   const newDate = new Date(date);
   newDate.setDate(newDate.getDate() + numDays);
   return newDate;
 }
 
-export function getRange(count) {
-  return Array.from({ length: count }, (_, i) => i);
+function getRange(count) {
+  const arr = [];
+  for (let idx = 0; idx < count; idx += 1) {
+    arr.push(idx);
+  }
+  return arr;
 }
 
 function getRandomInt(min, max) {

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -4381,6 +4381,11 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+memoize-one@^5.0.0:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.5.tgz#8cd3809555723a07684afafcd6f756072ac75d7e"
+  integrity sha512-ey6EpYv0tEaIbM/nTDOpHciXUvd+ackQrJgEzBwemhZZIWZjcyodqEcrmqDy2BKRTM3a65kKBV4WtLXJDt26SQ==
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -5567,8 +5572,9 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     strip-json-comments "~2.0.1"
 
 react-calendar-heatmap@../:
-  version "1.6.3"
+  version "1.8.0"
   dependencies:
+    memoize-one "^5.0.0"
     prop-types "^15.6.2"
 
 react-dev-utils@^5.0.2:

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -19,5 +19,9 @@ export function dateNDaysAgo(numDaysAgo) {
 }
 
 export function getRange(count) {
-  return Array.from({ length: count }, (_, i) => i);
+  const arr = [];
+  for (let idx = 0; idx < count; idx += 1) {
+    arr.push(idx);
+  }
+  return arr;
 }


### PR DESCRIPTION
See #69.

Verified that this now works in IE11 / Windows 8 in Virtualbox.

Before/after screenshots:

<img height=120 src=https://user-images.githubusercontent.com/396006/61435042-73cbe000-a8ec-11e9-9254-e2db57b4ff7a.png /> <img height=120 src=https://user-images.githubusercontent.com/396006/61435038-71698600-a8ec-11e9-93bc-84c7cd176667.png />

